### PR TITLE
Support edge labels for one-to-one and through relations 🩷

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
   "scripts": {
     "vscode:prepublish": "npm run build",
     "build": "tsc -p ./",
+    "test": "npm run build && node --test",
     "watch": "tsc -watch -p ./",
     "package": "vsce package",
     "publish": "vsce publish"

--- a/src/graphWebview.ts
+++ b/src/graphWebview.ts
@@ -8,7 +8,7 @@ function escapeLabel(s: string): string {
   return s.replace(/[^A-Za-z0-9_]/g, '_');
 }
 
-function buildMermaid(index: WorkspaceIndex): string {
+export function buildMermaid(index: WorkspaceIndex): string {
   const lines: string[] = ['erDiagram'];
   const modelNames = new Set<string>();
   for (const app of index.apps) {
@@ -46,6 +46,7 @@ function buildMermaid(index: WorkspaceIndex): string {
             : '}o--||';
         const parts: string[] = [f.name];
         if (f.onDelete) parts.push(f.onDelete);
+        if (f.throughModel) parts.push(`through ${f.throughModel}`);
         if (f.relatedName) parts.push(`as ${f.relatedName}`);
         const label = parts.length > 1
           ? `${parts[0]} [${parts.slice(1).join(', ')}]`

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -111,7 +111,7 @@ function extractRelatedName(argsBlock: string): string | undefined {
 
 function extractThroughModel(argsBlock: string): string | undefined {
   const m = argsBlock.match(
-    /through\s*=\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z_][A-Za-z0-9_.]*))/
+    /\bthrough\s*=\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z_][A-Za-z0-9_.]*))/
   );
   return m ? m[1] || m[2] || m[3] : undefined;
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -109,6 +109,13 @@ function extractRelatedName(argsBlock: string): string | undefined {
   return m ? m[1] || m[2] : undefined;
 }
 
+function extractThroughModel(argsBlock: string): string | undefined {
+  const m = argsBlock.match(
+    /through\s*=\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z_][A-Za-z0-9_.]*))/
+  );
+  return m ? m[1] || m[2] || m[3] : undefined;
+}
+
 function readBalancedArgs(lines: string[], startIdx: number): {
   argsBlock: string;
   endIdx: number;
@@ -241,6 +248,10 @@ export function parseModelsFile(filePath: string, content: string): ParsedModel[
           if (onDelete) field.onDelete = onDelete;
           const relatedName = extractRelatedName(argsInner);
           if (relatedName) field.relatedName = relatedName;
+          if (fieldType === 'ManyToManyField') {
+            const throughModel = extractThroughModel(argsInner);
+            if (throughModel) field.throughModel = throughModel;
+          }
         }
         model.fields.push(field);
         j = endIdx + 1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface ParsedField {
   relationKind?: RelationKind;
   onDelete?: string;
   relatedName?: string;
+  throughModel?: string;
   lineNumber: number;
 }
 

--- a/test/edge-labels.test.js
+++ b/test/edge-labels.test.js
@@ -1,0 +1,41 @@
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request === 'vscode') {
+    return {};
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const { buildMermaid } = require('../out/graphWebview');
+const { parseModelsFile } = require('../out/parser');
+
+test('labels OneToOneField metadata and ManyToManyField through models', () => {
+  const models = parseModelsFile('/project/app/models.py', `
+class User(models.Model):
+    profile = models.OneToOneField(
+        'Profile', on_delete=models.CASCADE, related_name='user'
+    )
+
+class Profile(models.Model):
+    pass
+
+class Group(models.Model):
+    members = models.ManyToManyField(
+        'User', through='Membership', related_name='groups'
+    )
+
+class Membership(models.Model):
+    pass
+`);
+  const mermaid = buildMermaid({
+    apps: [{ name: 'app', path: '/project/app', models }],
+    scannedAt: 0,
+  });
+
+  assert.match(mermaid, /User \|\|--\|\| Profile : "profile \[CASCADE, as user\]"/);
+  assert.match(mermaid, /Group \}o--o\{ User : "members \[through Membership, as groups\]"/);
+});

--- a/test/edge-labels.test.js
+++ b/test/edge-labels.test.js
@@ -13,6 +13,10 @@ Module._load = function (request, parent, isMain) {
 const { buildMermaid } = require('../out/graphWebview');
 const { parseModelsFile } = require('../out/parser');
 
+test.after(() => {
+  Module._load = originalLoad;
+});
+
 test('labels OneToOneField metadata and ManyToManyField through models', () => {
   const models = parseModelsFile('/project/app/models.py', `
 class User(models.Model):
@@ -25,7 +29,7 @@ class Profile(models.Model):
 
 class Group(models.Model):
     members = models.ManyToManyField(
-        'User', through='Membership', related_name='groups'
+        'User', passthrough='Ignored', through='Membership', related_name='groups'
     )
 
 class Membership(models.Model):


### PR DESCRIPTION
## Summary
- preserve existing OneToOneField metadata labels in the ER diagram
- parse ManyToManyField `through=` arguments and include the intermediate model in edge labels
- add a regression test covering both relation types

## Tests
- `npm test`
- `npm run build`
- `npm run package -- --out /tmp/django-orm-lens-issue-2.vsix`
- `git diff --check`

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mermaid relationship diagrams now include intermediary (“through”) model details for many-to-many relationships.
  * Relationship edge labels now surface additional metadata such as cascade behavior, related names, and through-model information.
* **Bug Fixes**
  * Improved Django relationship parsing so generated diagram connections better match configured model relationships.
* **Tests**
  * Added automated coverage to verify the generated edge labels include through-model and related metadata.
  * Added an npm `test` script to build the extension and run the Node test runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->