### PR TITLE
test: add Mezzanine golden fixture

### DIFF
--- a/cli/tests/fixtures/golden/README.md
+++ b/cli/tests/fixtures/golden/README.md
@@ -4,7 +4,7 @@ Vendored `models.py` files from established open-source Django projects. Used
 by `cli/tests/test_golden_fixtures.py` to prove `django-orm-lens` survives
 real-world code at scale.
 
-**Fetch date:** 2026-07-15
+**Fetch date:** 2026-07-16
 
 **Only `models.py` files are vendored** — no views, settings, URL routes, or
 other application code. Each file is stored at its original relative path so
@@ -16,11 +16,11 @@ this tree from GitHub via `gh api`.
 
 ## Attribution
 
-All projects below use permissive licences (Apache-2.0 or BSD-3-Clause) and
-allow verbatim redistribution of source files with copyright notice retained.
-The original licence and copyright notices remain in each file (top-of-file
-headers) and are preserved unchanged. Each vendored subtree is a partial
-copy, unmodified.
+All projects below use permissive licences (Apache-2.0, BSD-2-Clause, or
+BSD-3-Clause) and allow verbatim redistribution of source files with copyright
+notice retained. The original licence and copyright notices remain in each file
+(top-of-file headers) where present and are preserved unchanged. Each vendored
+subtree is a partial copy, unmodified.
 
 | Project      | Repo                                      | Licence      | Files fetched                                                                 |
 |--------------|-------------------------------------------|--------------|-------------------------------------------------------------------------------|
@@ -28,6 +28,7 @@ copy, unmodified.
 | Saleor       | https://github.com/saleor/saleor          | BSD-3-Clause | `saleor/{product,order,discount,warehouse}/models.py`                         |
 | Wagtail      | https://github.com/wagtail/wagtail        | BSD-3-Clause | `wagtail/models/{__init__,pages,sites}.py`                                    |
 | django-CMS   | https://github.com/django-cms/django-cms  | BSD-3-Clause | `cms/models/{__init__,pagemodel,placeholdermodel,pluginmodel}.py`             |
+| Mezzanine    | https://github.com/stephenmcd/mezzanine   | BSD-2-Clause | `mezzanine/blog/models.py`                                                    |
 
 Full licence texts are available in each upstream repository's `LICENSE`
 file at the linked URL above.

--- a/cli/tests/fixtures/golden/mezzanine/README.md
+++ b/cli/tests/fixtures/golden/mezzanine/README.md
@@ -1,0 +1,38 @@
+# Mezzanine golden fixture
+
+Vendored `models.py` from [Mezzanine](https://github.com/stephenmcd/mezzanine), a Django CMS/blog framework.
+
+**Upstream file:** `mezzanine/blog/models.py`  
+**Source URL:** https://raw.githubusercontent.com/stephenmcd/mezzanine/master/mezzanine/blog/models.py  
+**Fetch date:** 2026-07-16  
+**Upstream licence:** BSD-2-Clause
+
+Mezzanine is copyright (c) Stephen McDonald and contributors. Redistribution of this file is permitted under the BSD-2-Clause licence. The upstream file is preserved verbatim and unmodified.
+
+## BSD-2-Clause licence
+
+```
+Copyright (c) Stephen McDonald and contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/cli/tests/fixtures/golden/mezzanine/mezzanine/blog/models.py
+++ b/cli/tests/fixtures/golden/mezzanine/mezzanine/blog/models.py
@@ -1,0 +1,83 @@
+from django.db import models
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from mezzanine.conf import settings
+from mezzanine.core.fields import FileField
+from mezzanine.core.models import Displayable, Ownable, RichText, Slugged
+from mezzanine.generic.fields import CommentsField, RatingField
+from mezzanine.utils.models import AdminThumbMixin, upload_to
+
+
+class BlogPost(Displayable, Ownable, RichText, AdminThumbMixin):
+    """
+    A blog post.
+    """
+
+    categories = models.ManyToManyField(
+        "BlogCategory",
+        verbose_name=_("Categories"),
+        blank=True,
+        related_name="blogposts",
+    )
+    allow_comments = models.BooleanField(verbose_name=_("Allow comments"), default=True)
+    comments = CommentsField(verbose_name=_("Comments"))
+    rating = RatingField(verbose_name=_("Rating"))
+    featured_image = FileField(
+        verbose_name=_("Featured Image"),
+        upload_to=upload_to("blog.BlogPost.featured_image", "blog"),
+        format="Image",
+        max_length=255,
+        null=True,
+        blank=True,
+    )
+    related_posts = models.ManyToManyField(
+        "self", verbose_name=_("Related posts"), blank=True
+    )
+
+    admin_thumb_field = "featured_image"
+
+    class Meta:
+        verbose_name = _("Blog post")
+        verbose_name_plural = _("Blog posts")
+        ordering = ("-publish_date",)
+
+    def get_absolute_url(self):
+        """
+        URLs for blog posts can either be just their slug, or prefixed
+        with a portion of the post's publish date, controlled by the
+        setting ``BLOG_URLS_DATE_FORMAT``, which can contain the value
+        ``year``, ``month``, or ``day``. Each of these maps to the name
+        of the corresponding urlpattern, and if defined, we loop through
+        each of these and build up the kwargs for the correct urlpattern.
+        The order which we loop through them is important, since the
+        order goes from least granular (just year) to most granular
+        (year/month/day).
+        """
+        url_name = "blog_post_detail"
+        kwargs = {"slug": self.slug}
+        date_parts = ("year", "month", "day")
+        if settings.BLOG_URLS_DATE_FORMAT in date_parts:
+            url_name = "blog_post_detail_%s" % settings.BLOG_URLS_DATE_FORMAT
+            for date_part in date_parts:
+                date_value = str(getattr(self.publish_date, date_part))
+                if len(date_value) == 1:
+                    date_value = "0%s" % date_value
+                kwargs[date_part] = date_value
+                if date_part == settings.BLOG_URLS_DATE_FORMAT:
+                    break
+        return reverse(url_name, kwargs=kwargs)
+
+
+class BlogCategory(Slugged):
+    """
+    A category for grouping blog posts into a series.
+    """
+
+    class Meta:
+        verbose_name = _("Blog Category")
+        verbose_name_plural = _("Blog Categories")
+        ordering = ("title",)
+
+    def get_absolute_url(self):
+        return reverse("blog_post_list_category", kwargs={"category": self.slug})

--- a/cli/tests/test_golden_fixtures.py
+++ b/cli/tests/test_golden_fixtures.py
@@ -1,8 +1,8 @@
 """Golden fixture suite: parser must survive real-world Django code.
 
-Vendored `models.py` files from Zulip, Saleor, Wagtail, and django-CMS live
-under ``cli/tests/fixtures/golden/<project>/``. See that directory's README.md
-for attribution, licences, and fetch date.
+Vendored `models.py` files from Zulip, Saleor, Wagtail, django-CMS, and
+Mezzanine live under ``cli/tests/fixtures/golden/<project>/``. See that
+directory's README.md for attribution, licences, and fetch date.
 """
 
 from __future__ import annotations

--- a/scripts/fetch_golden_fixtures.py
+++ b/scripts/fetch_golden_fixtures.py
@@ -57,6 +57,13 @@ PROJECTS = {
             "cms/models/pluginmodel.py",
         ],
     },
+    "mezzanine": {
+        "repo": "stephenmcd/mezzanine",
+        "ref": "master",
+        "paths": [
+            "mezzanine/blog/models.py",
+        ],
+    },
 }
 
 


### PR DESCRIPTION
Adds a Mezzanine golden fixture under `cli/tests/fixtures/golden/mezzanine/`.

**Vendored upstream file**
- File: `mezzanine/blog/models.py`
- Source: https://raw.githubusercontent.com/stephenmcd/mezzanine/master/mezzanine/blog/models.py
- Upstream: `stephenmcd/mezzanine` @ `master`
- Fetch date: 2026-07-16

The file is preserved verbatim (mirrors the upstream path) and is attributed in `cli/tests/fixtures/golden/mezzanine/README.md` under the BSD-2-Clause licence.

**What this coverage exercises**
- Abstract/multi-base inheritance: `BlogPost` inherits from `Displayable`, `Ownable`, `RichText`, and `AdminThumbMixin`.
- Real-world custom field types and settings references (e.g. `FileField`, `CommentsField`, `RatingField`, `mezzanine.conf.settings`).
- Verifies the parser still finds ≥1 model and does not raise.

**Golden output generation**
The existing `cli/tests/test_golden_fixtures.py` parametrizes over fixture directories and runs `scan_workspace`; the new fixture is picked up automatically by directory discovery. `pytest` was run from `cli/`.

**Gates**
- `pytest -q` (from `cli/`): 45 passed.
- `ruff check ../scripts/fetch_golden_fixtures.py tests/test_golden_fixtures.py`: clean.
- Pre-existing `ruff` lints in parser/CLI source were left untouched (out of scope).

Closes #13

Prepared with AI assistance (Kimi K2.7 Code), human-reviewed before submission.
