### PR TITLE
feat(er): add Graphviz DOT export

### DIFF
--- a/cli/django_orm_lens/cli.py
+++ b/cli/django_orm_lens/cli.py
@@ -4,7 +4,7 @@ Zero-dep argparse CLI. Commands mirror what the VS Code extension does:
 
   django-orm-lens scan       — walk workspace, list every model
   django-orm-lens describe   — one model in detail
-  django-orm-lens er         — ER diagram: mermaid / dbml / d2 / plantuml
+  django-orm-lens er         — ER diagram: mermaid / dbml / d2 / plantuml / dot
   django-orm-lens hover      — compact hover card for one model
   django-orm-lens list       — flat list ``app.Model`` for shell piping
   django-orm-lens diff       — compare two schema JSON dumps
@@ -566,17 +566,20 @@ def build_parser() -> argparse.ArgumentParser:
 
     er = sub.add_parser(
         "er",
-        help="Emit an ER diagram — Mermaid, DBML, D2, or PlantUML (stdout or file)",
+        help=(
+            "Emit an ER diagram — Mermaid, DBML, D2, PlantUML, or Graphviz DOT "
+            "(stdout or file)"
+        ),
     )
     _add_scan_flags(er)
     er.add_argument(
         "--format", "-f",
-        choices=("mermaid", "dbml", "d2", "plantuml"),
+        choices=("mermaid", "dbml", "d2", "plantuml", "dot"),
         default="mermaid",
         help=(
             "Diagram language. mermaid renders natively on GitHub; dbml "
             "pastes into dbdiagram.io; d2 renders via the d2 CLI; plantuml "
-            "via any PlantUML server or IDE plugin"
+            "via any PlantUML server or IDE plugin; dot renders via Graphviz"
         ),
     )
     er.add_argument(
@@ -726,7 +729,7 @@ def _cmd_hello(_args: argparse.Namespace) -> int:
     print("  list               Flat app.Model list, pipes into shell")
     print("  describe <model>   Full field/relation/Meta detail for one model")
     print("  hover <model>      Compact hover-card markdown for a model")
-    print("  er                 ER diagram: mermaid / dbml / d2 / plantuml")
+    print("  er                 ER diagram: mermaid / dbml / d2 / plantuml / dot")
     print("  diff <old> <new>   Compare two schema JSON dumps and print the delta")
     print("  nplusone           Detect N+1 anti-patterns in views/tasks")
     print("  migration-risk     Flag risky migration operations")

--- a/cli/django_orm_lens/er_formats.py
+++ b/cli/django_orm_lens/er_formats.py
@@ -1,7 +1,7 @@
-"""Alternative ER-diagram serializers — DBML, D2, PlantUML.
+"""Alternative ER-diagram serializers — DBML, D2, PlantUML, Graphviz DOT.
 
 ``er --format mermaid`` stays the default (GitHub renders Mermaid inline in
-READMEs, issues, and PRs). These three cover the interchange formats the
+READMEs, issues, and PRs). These four cover the interchange formats the
 wider database-tooling community actually shares diagrams in:
 
 * **DBML** — the dbdiagram.io / dbdocs.io language. Paste the output into
@@ -12,8 +12,10 @@ wider database-tooling community actually shares diagrams in:
   Apps become nested containers, so big schemas stay readable.
 * **PlantUML** — the long-standing IDE/enterprise staple with crow's-foot
   notation via the ``entity`` syntax.
+* **Graphviz DOT** — the established graph interchange language emitted by
+  ``django-extensions graph_models``. Render locally with ``dot -Tsvg``.
 
-All three emitters walk the same :class:`~django_orm_lens.models.WorkspaceIndex`
+All four emitters walk the same :class:`~django_orm_lens.models.WorkspaceIndex`
 the Mermaid builder uses, resolve ``settings.AUTH_USER_MODEL`` identically,
 and skip relations whose target model lives outside the workspace — every
 format draws the same graph.
@@ -26,6 +28,8 @@ refs always point at a declared column.
 
 from __future__ import annotations
 
+import html
+import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -304,10 +308,101 @@ def build_plantuml(index: WorkspaceIndex) -> str:
     return "\n".join(lines) + "\n"
 
 
+# ---------------------------------------------------------------------------
+# Graphviz DOT
+# ---------------------------------------------------------------------------
+
+
+def _dot_quote(value: str) -> str:
+    """Return a quoted DOT string with JSON-compatible escaping."""
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _dot_table(model: ParsedModel) -> str:
+    """Graphviz HTML label for one model and its fields."""
+    pk = _pk_field(model)
+    rows = [
+        '<TABLE BORDER="1" CELLBORDER="0" CELLSPACING="0" CELLPADDING="4">',
+        (
+            '<TR><TD COLSPAN="2" BGCOLOR="#e8eef7">'
+            f"<B>{html.escape(model.name)}</B></TD></TR>"
+        ),
+    ]
+    if pk is None:
+        rows.append("<TR><TD ALIGN=\"LEFT\"><B>id</B></TD><TD>AutoField · PK</TD></TR>")
+    for field in model.fields:
+        if field.is_relation:
+            continue
+        name = html.escape(field.name)
+        field_type = html.escape(field.type)
+        if pk is not None and field.name == pk.name:
+            name = f"<B>{name}</B>"
+            field_type += " · PK"
+        rows.append(
+            f'<TR><TD ALIGN="LEFT">{name}</TD><TD>{field_type}</TD></TR>'
+        )
+    for field in model.fields:
+        if not field.is_relation:
+            continue
+        rows.append(
+            '<TR><TD ALIGN="LEFT">'
+            f"{html.escape(field.name)}</TD><TD>"
+            f"{html.escape(field.relation_kind or 'ForeignKey')} · FK</TD></TR>"
+        )
+    rows.append("</TABLE>")
+    return "<" + "".join(rows) + ">"
+
+
+def build_dot(index: WorkspaceIndex) -> str:
+    """Graphviz DOT diagram with app clusters and crow's-foot-style edges."""
+    lines: list[str] = [
+        "digraph django_orm_lens {",
+        '  graph [rankdir="LR", compound="true", fontname="Helvetica"];',
+        '  node [shape="plain", fontname="Helvetica"];',
+        '  edge [fontname="Helvetica", fontsize="10"];',
+        "",
+    ]
+    for app in index.apps:
+        lines.append(f"  subgraph {_dot_quote(f'cluster_{app.name}')} {{")
+        lines.append(f"    label={_dot_quote(app.name)};")
+        lines.append('    color="#b8c2cc";')
+        lines.append('    style="rounded";')
+        for model in app.models:
+            qualified = f"{app.name}.{model.name}"
+            lines.append(
+                f"    {_dot_quote(qualified)} [label={_dot_table(model)}];"
+            )
+        lines.append("  }")
+        lines.append("")
+
+    for edge in _collect_edges(index):
+        if edge.kind == "ManyToManyField":
+            arrowtail, arrowhead = "crow", "crow"
+        elif edge.kind == "OneToOneField":
+            arrowtail, arrowhead = "tee", "tee"
+        else:
+            arrowtail, arrowhead = "crow", "tee"
+        label_parts = [f"{edge.field} → {edge.target_pk}", edge.kind]
+        if edge.on_delete:
+            label_parts.append(edge.on_delete)
+        if edge.through:
+            label_parts.append(f"through {edge.through}")
+        lines.append(
+            f"  {_dot_quote(edge.src)} -> {_dot_quote(edge.target)} "
+            f"[label={_dot_quote(' / '.join(label_parts))}, dir=\"both\", "
+            f"arrowtail={_dot_quote(arrowtail)}, "
+            f"arrowhead={_dot_quote(arrowhead)}];"
+        )
+
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
 # Registry used by the CLI and the MCP server — mermaid is handled by the
 # original builder in cli.py and stays the default.
 ER_BUILDERS = {
     "dbml": build_dbml,
     "d2": build_d2,
     "plantuml": build_plantuml,
+    "dot": build_dot,
 }

--- a/cli/django_orm_lens/mcp_server.py
+++ b/cli/django_orm_lens/mcp_server.py
@@ -7,7 +7,7 @@ Exposes ten read-only tools that any MCP-compatible AI agent can call:
 * ``describe_model`` — full field/relation/Meta detail for one model
 * ``find_relations`` — inbound + outbound relations for one model
 * ``cascade_preview`` — group inbound relations by on_delete behavior
-* ``er_diagram``     — workspace ER diagram (mermaid / dbml / d2 / plantuml)
+* ``er_diagram``     — workspace ER diagram (mermaid / dbml / d2 / plantuml / dot)
 * ``describe_migration_dependency`` — per-app migration DAG from static AST parse
 * ``suggest_indexes`` — proposed ``Meta.indexes`` from workspace QuerySet usage
 * ``signal_graph``   — sender→signal→handler DAG from ``@receiver`` decorators
@@ -226,7 +226,7 @@ def _tool_er_diagram(args: dict[str, Any]) -> str:
     builder = ER_BUILDERS.get(fmt)
     if builder is None:
         raise ValueError(
-            f"unknown diagram_format {fmt!r}; use mermaid | dbml | d2 | plantuml"
+            f"unknown diagram_format {fmt!r}; use mermaid | dbml | d2 | plantuml | dot"
         )
     return builder(idx)
 
@@ -352,7 +352,7 @@ TOOLS: dict[str, dict[str, Any]] = {
         "description": (
             "Emit an ER diagram for the whole workspace. diagram_format "
             "picks the language: mermaid (default, renders on GitHub), "
-            "dbml (dbdiagram.io), d2, or plantuml." + _WORKSPACE_HINT
+            "dbml (dbdiagram.io), d2, plantuml, or Graphviz dot." + _WORKSPACE_HINT
         ),
     },
     "describe_migration_dependency": {

--- a/cli/tests/test_er_formats.py
+++ b/cli/tests/test_er_formats.py
@@ -1,4 +1,4 @@
-"""Tests for the DBML / D2 / PlantUML ER-diagram emitters.
+"""Tests for the DBML / D2 / PlantUML / Graphviz DOT ER-diagram emitters.
 
 The community-standard export formats must draw the *same graph* the
 Mermaid builder draws: identical relation resolution (including
@@ -17,7 +17,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from django_orm_lens.cli import main
-from django_orm_lens.er_formats import build_d2, build_dbml, build_plantuml
+from django_orm_lens.er_formats import build_d2, build_dbml, build_dot, build_plantuml
 from django_orm_lens.parser import DEFAULT_EXCLUDES, scan_workspace
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -67,6 +67,24 @@ class MiniappAllFormatsTest(unittest.TestCase):
         self.assertIn('entity "orders.Order" as orders_Order {', puml)
         self.assertIn("orders_Order }o--|| users_User : user / CASCADE", puml)
 
+    def test_dot_clusters_tables_and_edges(self) -> None:
+        dot = build_dot(self.index)
+        self.assertTrue(dot.startswith("digraph django_orm_lens {"))
+        self.assertIn('subgraph "cluster_orders" {', dot)
+        self.assertIn('"orders.Order" [label=<<TABLE', dot)
+        self.assertIn(
+            '"orders.Order" -> "users.User" '
+            '[label="user → id / ForeignKey / CASCADE", dir="both", '
+            'arrowtail="crow", arrowhead="tee"];',
+            dot,
+        )
+
+    def test_dot_never_leaks_absolute_paths(self) -> None:
+        dot = build_dot(self.index)
+        self.assertNotIn("C:/", dot)
+        self.assertNotIn("C:\\", dot)
+        self.assertNotIn(str(MINIAPP.resolve()), dot)
+
     def test_same_edge_set_as_mermaid(self) -> None:
         """Every format must draw the same number of relations."""
         _, mermaid_out, _ = _run(["er", "--path", str(MINIAPP)])
@@ -80,7 +98,13 @@ class MiniappAllFormatsTest(unittest.TestCase):
             for line in build_dbml(self.index).splitlines()
             if line.startswith("Ref: ")
         ]
+        dot_edges = [
+            line
+            for line in build_dot(self.index).splitlines()
+            if " -> " in line
+        ]
         self.assertEqual(len(mermaid_edges), len(dbml_refs))
+        self.assertEqual(len(mermaid_edges), len(dot_edges))
         self.assertGreater(len(dbml_refs), 0)
 
 
@@ -108,6 +132,9 @@ class SyntheticSchemaTest(unittest.TestCase):
         self.assertNotIn("id AutoField [pk]", dbml)
         puml = build_plantuml(idx)
         self.assertIn("* jti : CharField", puml)
+        dot = build_dot(idx)
+        self.assertIn("<B>jti</B></TD><TD>CharField · PK", dot)
+        self.assertNotIn("<B>id</B></TD><TD>AutoField · PK", dot)
 
     def test_self_fk_and_m2m_through(self) -> None:
         idx = self._index_for(
@@ -153,7 +180,7 @@ class SyntheticSchemaTest(unittest.TestCase):
             "    poll = models.ForeignKey(\n"
             "        'polls.Poll', on_delete=models.CASCADE)\n"
         )
-        for text in (build_dbml(idx), build_d2(idx), build_plantuml(idx)):
+        for text in (build_dbml(idx), build_d2(idx), build_plantuml(idx), build_dot(idx)):
             self.assertNotIn("polls.Poll", text)
 
     def test_fk_ref_targets_explicit_pk_column(self) -> None:
@@ -178,6 +205,8 @@ class SyntheticSchemaTest(unittest.TestCase):
         d2 = build_d2(idx)
         self.assertIn("blog.Order.product -> blog.Product.sku", d2)
         self.assertNotIn("blog.Product.id", d2)
+        dot = build_dot(idx)
+        self.assertIn("product → sku / ForeignKey / PROTECT", dot)
 
 
 class CliWiringTest(unittest.TestCase):
@@ -187,6 +216,7 @@ class CliWiringTest(unittest.TestCase):
             ("dbml", "Table orders.Order {"),
             ("d2", "shape: sql_table"),
             ("plantuml", "@startuml"),
+            ("dot", "digraph django_orm_lens"),
         ):
             code, out, _ = _run(["er", "--path", str(MINIAPP), "--format", fmt])
             self.assertEqual(code, 0, f"{fmt} exited {code}")

--- a/cli/tests/test_mcp_server.py
+++ b/cli/tests/test_mcp_server.py
@@ -252,6 +252,13 @@ class HappyPathTest(unittest.TestCase):
         self.assertIn("myapp.Author", raw)
         self.assertIn("myapp.Book", raw)
 
+    def test_er_diagram_dot_format(self) -> None:
+        result = _tool_er_diagram(
+            {"workspace_root": str(self.tmp), "diagram_format": "dot"}
+        )
+        self.assertTrue(result.startswith("digraph django_orm_lens {"))
+        self.assertIn('subgraph "cluster_myapp" {', result)
+
     def test_describe_model_returns_field_detail(self) -> None:
         raw = _tool_describe_model(
             {"workspace_root": str(self.tmp), "model": "myapp.Book"}


### PR DESCRIPTION
## Summary

- add a Graphviz DOT serializer with app clusters and table-shaped model nodes
- render primary keys, relation fields, and crow's-foot-style cardinalities
- expose `dot` through both the CLI and MCP ER-diagram interfaces
- add edge-parity, path-safety, CLI, and MCP coverage

## Why

Graphviz DOT is a common interchange format for Django schema diagrams, especially for users migrating from `django-extensions graph_models`. This adds it alongside the existing Mermaid, DBML, D2, and PlantUML exporters.

Closes #48.

## Validation

- `python -m pytest -q` — 317 passed, 20 subtests passed
- `python -m ruff check django_orm_lens tests`
- `python -m mypy django_orm_lens`
- generated the miniapp fixture with `er --format dot`
- rendered the generated document with `dot -Tsvg` without warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Graphviz DOT support for entity-relationship diagrams.
  * Added `dot` as an available output format for the CLI and diagram tool.
  * DOT diagrams include model tables, primary keys, foreign-key relationships, and relationship metadata.

* **Documentation**
  * Updated command help and format descriptions to document Graphviz DOT output.

* **Tests**
  * Added coverage for DOT generation through the CLI and diagram tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->