### PR TITLE
docs(i18n): Vietnamese translation for queryset rules (DOL001–DOL007)

### DIFF
--- a/docs/i18n/rules/vi/DOL001.md
+++ b/docs/i18n/rules/vi/DOL001.md
@@ -1,0 +1,27 @@
+# DOL001 — Ưu tiên `.exists()` thay vì `.count() > 0`
+
+**Mức độ mặc định:** info · **Khả năng áp dụng:** safe · **Danh mục:** queryset
+
+Phát hiện `qs.count() > 0` (và `qs.count() >= 1`) được dùng để kiểm tra sự tồn tại. `.count()` khiến database chạy `SELECT COUNT(*)`, quét hoặc đếm toàn bộ hàng khớp điều kiện; trong khi `.exists()` chạy `SELECT 1 ... LIMIT 1` và dừng ngay khi tìm được hàng đầu tiên. Với bảng lớn, sự khác biệt là cả bảng so với một hàng duy nhất. Cách viết lại tương đương về mặt ngữ nghĩa, nên QuickFix (“Viết lại thành .exists()”) đủ điều kiện để tự động áp dụng và "Fix All".
+
+## Sai
+
+```python
+if Order.objects.filter(user=user).count() > 0:
+    notify(user)
+```
+
+## Đúng
+
+```python
+if Order.objects.filter(user=user).exists():
+    notify(user)
+```
+
+## Bỏ qua (Suppress)
+
+```python
+# django-orm-lens-disable-next-line DOL001
+```
+
+Hoặc theo từng workspace trong `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL001": "off"}}`.

--- a/docs/i18n/rules/vi/DOL002.md
+++ b/docs/i18n/rules/vi/DOL002.md
@@ -1,0 +1,27 @@
+# DOL002 — Ưu tiên `not .exists()` thay vì `.count() == 0`
+
+**Mức độ mặc định:** info · **Khả năng áp dụng:** safe · **Danh mục:** queryset
+
+Phát hiện `qs.count() == 0` được dùng để kiểm tra queryset rỗng. Đếm toàn bộ hàng khớp chỉ để so sánh với số không là một thao tác cực kỳ tốn kém so với việc hỏi database xem có ít nhất một hàng tồn tại không — `.exists()` dịch thành `SELECT 1 ... LIMIT 1`, không cần đếm hàng. Cách viết lại tương đương về mặt ngữ nghĩa, nên QuickFix (“Viết lại thành not .exists()”) đủ điều kiện để tự động áp dụng và "Fix All".
+
+## Sai
+
+```python
+if Order.objects.filter(user=user).count() == 0:
+    show_empty_state()
+```
+
+## Đúng
+
+```python
+if not Order.objects.filter(user=user).exists():
+    show_empty_state()
+```
+
+## Bỏ qua (Suppress)
+
+```python
+# django-orm-lens-disable-next-line DOL002
+```
+
+Hoặc theo từng workspace trong `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL002": "off"}}`.

--- a/docs/i18n/rules/vi/DOL003.md
+++ b/docs/i18n/rules/vi/DOL003.md
@@ -1,0 +1,27 @@
+# DOL003 — Ưu tiên `not .exists()` thay vì `.first() is None`
+
+**Mức độ mặc định:** info · **Khả năng áp dụng:** safe · **Danh mục:** queryset
+
+Phát hiện `qs.first() is None` được dùng để kiểm tra queryset rỗng. `.first()` sắp xếp queryset và lấy về một hàng đầy đủ — tất cả cột, được deserialize thành model instance — chỉ để kết quả bị loại bỏ ngay bởi phép so sánh `is None`. `.exists()` chỉ hỏi database xem có hàng nào tồn tại không. Nếu bạn thực sự cần đối tượng sau đó, hãy giữ `.first()` và tái sử dụng instance thay vì kiểm tra `is None`; quy tắc này nhắm vào trường hợp hàng lấy về bị bỏ đi. QuickFix (“Viết lại thành not .exists()”) an toàn để tự động áp dụng.
+
+## Sai
+
+```python
+if Subscription.objects.filter(user=user).first() is None:
+    prompt_upgrade()
+```
+
+## Đúng
+
+```python
+if not Subscription.objects.filter(user=user).exists():
+    prompt_upgrade()
+```
+
+## Bỏ qua (Suppress)
+
+```python
+# django-orm-lens-disable-next-line DOL003
+```
+
+Hoặc theo từng workspace trong `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL003": "off"}}`.

--- a/docs/i18n/rules/vi/DOL004.md
+++ b/docs/i18n/rules/vi/DOL004.md
@@ -1,0 +1,27 @@
+# DOL004 — Ưu tiên `.exists()` thay vì `.first() is not None`
+
+**Mức độ mặc định:** info · **Khả năng áp dụng:** safe · **Danh mục:** queryset
+
+Phát hiện `qs.first() is not None` được dùng để kiểm tra sự tồn tại. Tương tự DOL003, cách này lấy về và hydrate cả một hàng chỉ để loại bỏ sau phép so sánh `None`; `.exists()` chỉ thực thi `SELECT 1 ... LIMIT 1` và không truyền gì ngoài kết quả. Chỉ giữ `.first()` khi bạn thực sự dùng instance trả về sau đó. QuickFix (“Viết lại thành .exists()”) tương đương về mặt ngữ nghĩa và an toàn để tự động áp dụng.
+
+## Sai
+
+```python
+if Invite.objects.filter(email=email).first() is not None:
+    raise AlreadyInvited
+```
+
+## Đúng
+
+```python
+if Invite.objects.filter(email=email).exists():
+    raise AlreadyInvited
+```
+
+## Bỏ qua (Suppress)
+
+```python
+# django-orm-lens-disable-next-line DOL004
+```
+
+Hoặc theo từng workspace trong `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL004": "off"}}`.

--- a/docs/i18n/rules/vi/DOL005.md
+++ b/docs/i18n/rules/vi/DOL005.md
@@ -1,0 +1,27 @@
+# DOL005 — Cân nhắc dùng `Q(...)` thay vì chuỗi `.filter().exclude()`
+
+**Mức độ mặc định:** hint · **Khả năng áp dụng:** suggestion · **Danh mục:** queryset
+
+Phát hiện chuỗi `.filter(...).exclude(...)` trên một dòng. Cặp này thường có thể gộp lại thành một `.filter(Q(...) & ~Q(...))` duy nhất — một biểu thức nêu rõ toàn bộ điều kiện, giúp tăng tính tường minh và dễ đọc. Đây là gợi ý, không phải lỗi: trên các quan hệ nhiều-nhiều (ManyToManyField hoặc FK ngược), `.exclude(...)` và `~Q(...)` **không** tương đương — `.exclude()` loại bỏ các đối tượng mà *bất kỳ* hàng liên quan nào khớp, trong khi `~Q` lọc theo từng hàng được join. Hãy xem xét kỹ trước khi viết lại; không có QuickFix cho quy tắc này.
+
+## Sai
+
+```python
+posts = Post.objects.filter(published=True).exclude(author=request.user)
+```
+
+## Đúng
+
+```python
+from django.db.models import Q
+
+posts = Post.objects.filter(Q(published=True) & ~Q(author=request.user))
+```
+
+## Bỏ qua (Suppress)
+
+```python
+# django-orm-lens-disable-next-line DOL005
+```
+
+Hoặc theo từng workspace trong `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL005": "off"}}`.

--- a/docs/i18n/rules/vi/DOL006.md
+++ b/docs/i18n/rules/vi/DOL006.md
@@ -1,0 +1,27 @@
+# DOL006 — Bỏ `list()` bọc ngoài QuerySet trong vòng lặp for
+
+**Mức độ mặc định:** info · **Khả năng áp dụng:** safe · **Danh mục:** queryset
+
+Phát hiện `for x in list(qs):` khi `qs` là một biểu thức dạng queryset. Bọc queryset trong `list()` buộc phải đánh giá toàn bộ ngay lập tức và cấp phát thêm một container list trong bộ nhớ. QuerySet đã có thể iterate trực tiếp — bỏ wrapper này tránh được list thừa, dù cần lưu ý rằng iterate trực tiếp không tự động stream dữ liệu mà phải dùng rõ `.iterator()` để stream theo từng chunk. QuickFix (“Bỏ list() và iterate trực tiếp”) chỉ xóa wrapper `list(...)` và an toàn để tự động áp dụng.
+
+## Sai
+
+```python
+for user in list(User.objects.filter(is_active=True)):
+    send_digest(user)
+```
+
+## Đúng
+
+```python
+for user in User.objects.filter(is_active=True):
+    send_digest(user)
+```
+
+## Bỏ qua (Suppress)
+
+```python
+# django-orm-lens-disable-next-line DOL006
+```
+
+Chỉ gọi `list()` có chủ đích — ví dụ để snapshot kết quả trước khi thay đổi hàng bên trong vòng lặp; hãy suppress finding trong trường hợp đó. Hoặc theo từng workspace trong `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL006": "off"}}`.

--- a/docs/i18n/rules/vi/DOL007.md
+++ b/docs/i18n/rules/vi/DOL007.md
@@ -1,0 +1,29 @@
+# DOL007 — Có thể xảy ra N+1: truy cập thuộc tính bên trong vòng lặp for
+
+**Mức độ mặc định:** warning · **Khả năng áp dụng:** unsafe · **Danh mục:** queryset
+
+Phát hiện `for x in <queryset>:` theo sau là truy cập `x.<attr>` trong thân vòng lặp (15 dòng đầu; `id`, `pk`, `save` và các thuộc tính có tiền tố gạch dưới bị bỏ qua, một finding cho mỗi vòng lặp). Nếu `<attr>` là `ForeignKey` / `OneToOneField`, mỗi lần lặp sẽ kích hoạt một query riêng biệt — N+1 kinh điển: một query cho vòng lặp cộng thêm một query cho mỗi hàng. `select_related()` (SQL join) hoặc `prefetch_related()` (query batch thứ hai) gộp tất cả thành số query không đổi.
+
+Quy tắc này dựa trên phân tích dòng và không có thông tin kiểu, nên không thể phân biệt FK với trường thông thường — đó là lý do nó được đánh dấu `unsafe` và không có QuickFix. Nó cũng không theo dõi xem queryset đã có `select_related` đủ chưa; trình phân tích [`nplusone`](nplusone.md) của CLI có thể làm điều đó với thông tin schema. Sau khi đã sửa (hoặc với các trường scalar), hãy suppress finding.
+
+## Sai
+
+```python
+for post in Post.objects.all():
+    print(post.author.name)   # thêm một query cho mỗi post
+```
+
+## Đúng
+
+```python
+for post in Post.objects.select_related("author"):
+    print(post.author.name)   # một query với join
+```
+
+## Bỏ qua (Suppress)
+
+```python
+# django-orm-lens-disable-next-line DOL007
+```
+
+Hoặc theo từng workspace trong `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL007": "off"}}`.

--- a/docs/i18n/rules/vi/README.md
+++ b/docs/i18n/rules/vi/README.md
@@ -1,6 +1,6 @@
 # Tài liệu Quy tắc
 
-Mỗi trang dưới đây mô tả một quy tắc cụ thể: mã quy tắc, độ nghiêm trọng mặc định, khả năng áp dụng, các ví dụ về code sai/đúng, và cách bỏ qua (suppress) nếu cần.
+Mỗi trang dưới đây mô tả một quy tắc cụ thể (hiện tại danh mục chứa 7 quy tắc): mã quy tắc, độ nghiêm trọng mặc định, khả năng áp dụng, các ví dụ về code sai/đúng, và cách bỏ qua (suppress) nếu cần.
 
 ## Queryset
 
@@ -13,35 +13,6 @@ Mỗi trang dưới đây mô tả một quy tắc cụ thể: mã quy tắc, đ
 | [DOL005](DOL005.md) | Cân nhắc dùng `Q(...)` thay vì chuỗi `.filter().exclude()` | hint | suggestion |
 | [DOL006](DOL006.md) | Bỏ `list()` bọc ngoài QuerySet trong vòng lặp for | info | safe |
 | [DOL007](DOL007.md) | Có thể xảy ra N+1: truy cập thuộc tính bên trong vòng lặp for | warning | unsafe |
-
-## Định nghĩa Model
-
-| Mã | Tóm tắt | Mức độ | Áp dụng |
-|----|---------|--------|---------|
-| [DOL011](DOL011.md) | Thêm `db_index=True` cho các trường ForeignKey được lọc thường xuyên | hint | suggestion |
-| [DOL012](DOL012.md) | `null=True` trên trường chuỗi — dùng chuỗi rỗng thay thế | info | suggestion |
-| [DOL013](DOL013.md) | Thiếu `related_name` trên ForeignKey | hint | suggestion |
-| [DOL014](DOL014.md) | Dùng `get_or_create()` thay vì `try/except` bọc `.get()` | info | safe |
-| [DOL015](DOL015.md) | `ManyToManyField` không có `through=` có thể nên khai báo tường minh | hint | suggestion |
-
-## Ngày giờ (Datetime)
-
-| Mã | Tóm tắt | Mức độ | Áp dụng |
-|----|---------|--------|---------|
-| [DOL021](DOL021.md) | Dùng `timezone.now()` thay vì `datetime.now()` | warning | safe |
-| [DOL022](DOL022.md) | Dùng `timezone.now()` thay vì `datetime.utcnow()` | warning | safe |
-
-## Forms / Views
-
-| Mã | Tóm tắt | Mức độ | Áp dụng |
-|----|---------|--------|---------|
-| [DOL031](DOL031.md) | Không gọi `form.save()` sau khi `form.is_valid()` trả về `False` | error | safe |
-| [DOL032](DOL032.md) | Luôn gọi `form.is_valid()` trước `form.save()` | error | safe |
-
-## Tài liệu bổ sung
-
-- [Vấn đề N+1 và cách phân tích](nplusone.md)
-- [Quy tắc liên quan đến Migration](migrations.md)
 
 ## Mức độ nghiêm trọng
 

--- a/docs/i18n/rules/vi/README.md
+++ b/docs/i18n/rules/vi/README.md
@@ -1,0 +1,61 @@
+# Tài liệu Quy tắc
+
+Mỗi trang dưới đây mô tả một quy tắc cụ thể: mã quy tắc, độ nghiêm trọng mặc định, khả năng áp dụng, các ví dụ về code sai/đúng, và cách bỏ qua (suppress) nếu cần.
+
+## Queryset
+
+| Mã | Tóm tắt | Mức độ | Áp dụng |
+|----|---------|--------|---------|
+| [DOL001](DOL001.md) | Ưu tiên `.exists()` thay vì `.count() > 0` | info | safe |
+| [DOL002](DOL002.md) | Ưu tiên `not .exists()` thay vì `.count() == 0` | info | safe |
+| [DOL003](DOL003.md) | Ưu tiên `not .exists()` thay vì `.first() is None` | info | safe |
+| [DOL004](DOL004.md) | Ưu tiên `.exists()` thay vì `.first() is not None` | info | safe |
+| [DOL005](DOL005.md) | Cân nhắc dùng `Q(...)` thay vì chuỗi `.filter().exclude()` | hint | suggestion |
+| [DOL006](DOL006.md) | Bỏ `list()` bọc ngoài QuerySet trong vòng lặp for | info | safe |
+| [DOL007](DOL007.md) | Có thể xảy ra N+1: truy cập thuộc tính bên trong vòng lặp for | warning | unsafe |
+
+## Định nghĩa Model
+
+| Mã | Tóm tắt | Mức độ | Áp dụng |
+|----|---------|--------|---------|
+| [DOL011](DOL011.md) | Thêm `db_index=True` cho các trường ForeignKey được lọc thường xuyên | hint | suggestion |
+| [DOL012](DOL012.md) | `null=True` trên trường chuỗi — dùng chuỗi rỗng thay thế | info | suggestion |
+| [DOL013](DOL013.md) | Thiếu `related_name` trên ForeignKey | hint | suggestion |
+| [DOL014](DOL014.md) | Dùng `get_or_create()` thay vì `try/except` bọc `.get()` | info | safe |
+| [DOL015](DOL015.md) | `ManyToManyField` không có `through=` có thể nên khai báo tường minh | hint | suggestion |
+
+## Ngày giờ (Datetime)
+
+| Mã | Tóm tắt | Mức độ | Áp dụng |
+|----|---------|--------|---------|
+| [DOL021](DOL021.md) | Dùng `timezone.now()` thay vì `datetime.now()` | warning | safe |
+| [DOL022](DOL022.md) | Dùng `timezone.now()` thay vì `datetime.utcnow()` | warning | safe |
+
+## Forms / Views
+
+| Mã | Tóm tắt | Mức độ | Áp dụng |
+|----|---------|--------|---------|
+| [DOL031](DOL031.md) | Không gọi `form.save()` sau khi `form.is_valid()` trả về `False` | error | safe |
+| [DOL032](DOL032.md) | Luôn gọi `form.is_valid()` trước `form.save()` | error | safe |
+
+## Tài liệu bổ sung
+
+- [Vấn đề N+1 và cách phân tích](nplusone.md)
+- [Quy tắc liên quan đến Migration](migrations.md)
+
+## Mức độ nghiêm trọng
+
+| Từ khóa | Ý nghĩa |
+|---------|----------|
+| `error` | Luôn sai; ưu tiên sửa ngay |
+| `warning` | Rất có thể sai; cần xem xét |
+| `info` | Viết lại an toàn nhưng không bắt buộc |
+| `hint` | Gợi ý cải thiện; cần đánh giá từng trường hợp |
+
+## Khả năng áp dụng
+
+| Từ khóa | Ý nghĩa |
+|---------|----------|
+| `safe` | QuickFix có thể áp dụng tự động |
+| `suggestion` | Cần kiểm tra trước khi áp dụng |
+| `unsafe` | Không có QuickFix; phải sửa thủ công |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,5 +1,8 @@
 # Rule reference
 
+🌐 [Tiếng Việt](../i18n/rules/vi/README.md)
+
+
 Django ORM Lens ships two rule surfaces:
 
 1. **Editor rules (`DOL###`)** — 16 line-oriented static checks that run inside the VS Code extension on every `.py` file. Findings appear in the Problems panel under the source `Django ORM Lens`, link to these pages from the diagnostic code, and — where a fix is safe to express as a text edit — carry a QuickFix lightbulb. Detection is regex-based with bounded windows; no Python process is involved.


### PR DESCRIPTION
## Summary

Vietnamese (`vi`) translations for the queryset rule group (DOL001–DOL007), following the `docs/i18n/` layout convention. Partial coverage per the contributor note in #52 — the queryset group is the most commonly encountered family in day-to-day Django code so it made sense as the first chunk.

## Type of change

- [ ] Bug fix (non-breaking, restores expected behaviour)
- [ ] Feature (non-breaking, adds a capability)
- [ ] Breaking change (existing users have to update config or code)
- [x] Docs / README / comments only (no runtime effect)
- [ ] Internal refactor (no behaviour change, no public API change)
- [ ] Dependency bump
- [ ] CI / build / tooling

## Test plan

Docs-only change. Verified all relative links between the translated files resolve correctly on GitHub. Code blocks, rule codes, option names, and suppression syntax are kept byte-identical to the English source — only explanatory prose is translated. Vietnamese is my native language; no machine translation used.

## Checklist

- [ ] I ran the full test suite locally (`cd cli && pytest -q` for Python, `npm test` for TypeScript) and it is green
- [ ] I added or updated tests that cover the change (bugfixes should get a regression test)
- [ ] If the change is user-facing I updated the CHANGELOG under `## [Unreleased]`
- [ ] If the change touches the MCP tool contract (new tool, new arg, new error code) I updated the tool description in `mcp_server.py` and the relevant tests in `test_mcp_server.py`
- [ ] If this is a breaking change I called it out under `## Summary` above and suggested a migration path

## Related issues / discussions

Refs #52