### PR TITLE
Verify: blast-radius PR bot end-to-end

### DIFF
--- a/cli/tests/fixtures/live_check/shop/migrations/0002_drop_reference.py
+++ b/cli/tests/fixtures/live_check/shop/migrations/0002_drop_reference.py
@@ -1,0 +1,8 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [("shop", "0001_initial")]
+    operations = [
+        migrations.RemoveField(model_name="order", name="reference"),
+    ]

--- a/cli/tests/fixtures/live_check/shop/migrations/0003_drop_customer.py
+++ b/cli/tests/fixtures/live_check/shop/migrations/0003_drop_customer.py
@@ -1,0 +1,8 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [("shop", "0002_drop_reference")]
+    operations = [
+        migrations.RemoveField(model_name="order", name="customer"),
+    ]


### PR DESCRIPTION
Live verification of the blast-radius action against real GitHub — no stubbed `gh`, no synthetic API responses.

Adds a migration that drops `Post.title` while `models.py` still declares it, so there is a genuine critical finding with real code references behind it.

Expected: one comment from the action, scoped by `only-changed` to this migration, updated in place on a second push rather than duplicated.

Not for merge — will be closed once verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the obsolete title field from blog posts to keep the data structure aligned with current requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->