### PR TITLE
Fix missing models import in test fixtures

### DIFF
--- a/test/fixtures/parity_input.py
+++ b/test/fixtures/parity_input.py
@@ -1,3 +1,5 @@
+from django.db import models
+
 class Author(models.Model):
     name = models.CharField(max_length=100)
 


### PR DESCRIPTION
## Summary

Found a minor issue where the `models` module wasn't explicitly imported in the `parity_input.py` test fixture. This caused undefined name errors during linting. Added the missing `from django.db import models` import to resolve it and keep the test suite completely green.

## Type of change

- [x] Bug fix (non-breaking, restores expected behaviour)
- [ ] Feature (non-breaking, adds a capability)
- [ ] Breaking change (existing users have to update config or code)
- [ ] Docs / README / comments only (no runtime effect)
- [ ] Internal refactor (no behaviour change, no public API change)
- [ ] Dependency bump
- [ ] CI / build / tooling

## Test plan

```bash
ruff check test/fixtures/parity_input.py
```
Verified the linting passes without the F821 undefined name error.

## Checklist

- [x] I ran the full test suite locally (`cd cli && pytest -q` for Python, `npm test` for TypeScript) and it is green
- [ ] I added or updated tests that cover the change (bugfixes should get a regression test)
- [ ] If the change is user-facing I updated the CHANGELOG under `## [Unreleased]`
- [ ] If the change touches the MCP tool contract (new tool, new arg, new error code) I updated the tool description in `mcp_server.py` and the relevant tests in `test_mcp_server.py`
- [ ] If this is a breaking change I called it out under `## Summary` above and suggested a migration path

## Related issues / discussions
