### PR TITLE
chore(glama): declare maintainer so the catalog entry can be claimed

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["FROWNINGdev"]
+}


### PR DESCRIPTION
glama.ai lists our MCP server, but the page still shows a **Claim** button — the entry is unowned. That means catalog metadata cannot be corrected and build-failure notifications have no verified recipient.

Their schema (`https://glama.ai/mcp/schemas/server.json`, draft-07) requires exactly one field: `maintainers`, a list of GitHub usernames permitted to maintain the server.

This sits alongside the manifests other catalogs already read — `smithery.yaml` for Smithery, `cli/server.json` for the MCP Registry.

### Why now

Glama sent a build-failure notice. Everything reproducible on our side is healthy:

- `docker build .` from the repo root succeeds; `django-orm-lens 1.12.0` installs from PyPI.
- The resulting image answers the MCP `initialize` handshake over stdio, protocol `2024-11-05`.
- stdout carries JSON-RPC only — the readiness banner correctly goes to stderr.
- The published `ghcr.io/frowningdev/django-orm-lens:latest` behaves identically.

So this PR claims the listing; it is not itself the build fix. The build log lives behind the Glama account and is needed before anything else can be diagnosed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Glama MCP server metadata and schema information.
  * Listed the project maintainer in the server details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->