### PR TITLE
chore(deps): pin @types/vscode to engines.vscode via dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,14 @@ updates:
     ignore:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # @types/vscode is not a normal dev dep: it must track engines.vscode
+      # (currently ^1.85.0), not latest. vsce refuses to package when the
+      # types outrun the declared engine --
+      #   '@types/vscode ^1.134.0 greater than engines.vscode ^1.85.0'
+      # -- which is exactly what turned PR #89 red on 2026-08-24. Raise this
+      # by hand, together with engines.vscode, when we deliberately drop
+      # support for older VS Code builds.
+      - dependency-name: "@types/vscode"
 
   # Docker — root Dockerfile bakes the GHCR image.
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Problem

Dependabot PR #89 (`@types/vscode` 1.125.0 → 1.134.0) fails the `build` job:

```
##[error] @types/vscode ^1.134.0 greater than engines.vscode ^1.85.0.
Either upgrade engines.vscode or use an older @types/vscode version
```

`vsce package` treats `@types/vscode` as a declaration of the minimum API surface the extension compiles against, so it must never exceed `engines.vscode`.

## Why not just bump `engines.vscode`

That would make the extension uninstallable on every VS Code older than 1.134 — a real compatibility loss traded for a dev-only type package. The types are the side that should stay pinned.

## Change

Add `@types/vscode` to the npm `ignore:` list in `.github/dependabot.yml`, with no `update-types` filter, so **all** version updates are held. It now moves only by hand, in the same commit that raises `engines.vscode`.

Follows the existing precedent in this file (`typescript` majors, `python` base-image minors).

## Follow-up

PR #89 is closed as won't-fix — Dependabot will not reopen it once this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated dependency updates for VS Code type definitions are now paused, requiring manual review for compatibility with the supported VS Code version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->