### PR TITLE
docs(i18n): add Italian queryset rule translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for `DOL011` through `DOL015` is now available in Italian, with a dedicated
   index linked from the complete rule reference. Refs #52.
 
+- **Italian translations for the queryset rules.** The documentation for
+  `DOL001` through `DOL008` is now available in Italian and linked from the
+  locale index. Refs #98.
+
 ### Fixed
 
 - **DOL007 no longer fires on attribute accesses that cost nothing.**

--- a/docs/i18n/rules/it/DOL001.md
+++ b/docs/i18n/rules/it/DOL001.md
@@ -1,4 +1,4 @@
-# DOL001 - Preferire .exists() a .count() > 0
+# DOL001 — Preferire .exists() a .count() > 0
 
 **Gravità predefinita:** info · **Applicabilità:** safe · **Categoria:** queryset
 

--- a/docs/i18n/rules/it/DOL001.md
+++ b/docs/i18n/rules/it/DOL001.md
@@ -1,0 +1,27 @@
+# DOL001 - Preferire .exists() a .count() > 0
+
+**Gravità predefinita:** info · **Applicabilità:** safe · **Categoria:** queryset
+
+Rileva `qs.count() > 0` (e `qs.count() >= 1`) usato come test di esistenza. `.count()` fa eseguire al database `SELECT COUNT(*)`, che scansiona o conta ogni riga corrispondente; `.exists()` esegue `SELECT 1 ... LIMIT 1` e si ferma al primo risultato. Sulle tabelle di grandi dimensioni, la differenza consiste nell'esaminare l'intera tabella anziché una sola riga. La riscrittura è semanticamente identica, quindi la QuickFix ("Rewrite to .exists()") può essere applicata automaticamente e tramite "Fix All".
+
+## Non corretto
+
+```python
+if Order.objects.filter(user=user).count() > 0:
+    notify(user)
+```
+
+## Corretto
+
+```python
+if Order.objects.filter(user=user).exists():
+    notify(user)
+```
+
+## Soppressione
+
+```python
+# django-orm-lens-disable-next-line DOL001
+```
+
+In alternativa, disattiva la regola per l'area di lavoro in `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL001": "off"}}`.

--- a/docs/i18n/rules/it/DOL002.md
+++ b/docs/i18n/rules/it/DOL002.md
@@ -1,0 +1,27 @@
+# DOL002 - Preferire not .exists() a .count() == 0
+
+**Gravità predefinita:** info · **Applicabilità:** safe · **Categoria:** queryset
+
+Rileva `qs.count() == 0` usato per verificare se un queryset è vuoto. Contare tutte le righe corrispondenti soltanto per confrontare il risultato con zero richiede molto più lavoro che chiedere al database se esista almeno una riga: `.exists()` viene tradotto in `SELECT 1 ... LIMIT 1`, senza dover contare le righe. La riscrittura è semanticamente identica, quindi la QuickFix ("Rewrite to not .exists()") può essere applicata automaticamente e tramite "Fix All".
+
+## Non corretto
+
+```python
+if Order.objects.filter(user=user).count() == 0:
+    show_empty_state()
+```
+
+## Corretto
+
+```python
+if not Order.objects.filter(user=user).exists():
+    show_empty_state()
+```
+
+## Soppressione
+
+```python
+# django-orm-lens-disable-next-line DOL002
+```
+
+In alternativa, disattiva la regola per l'area di lavoro in `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL002": "off"}}`.

--- a/docs/i18n/rules/it/DOL002.md
+++ b/docs/i18n/rules/it/DOL002.md
@@ -1,4 +1,4 @@
-# DOL002 - Preferire not .exists() a .count() == 0
+# DOL002 — Preferire not .exists() a .count() == 0
 
 **Gravità predefinita:** info · **Applicabilità:** safe · **Categoria:** queryset
 

--- a/docs/i18n/rules/it/DOL003.md
+++ b/docs/i18n/rules/it/DOL003.md
@@ -1,0 +1,27 @@
+# DOL003 - Preferire not .exists() a .first() is None
+
+**Gravità predefinita:** info · **Applicabilità:** safe · **Categoria:** queryset
+
+Rileva `qs.first() is None` usato per verificare se un queryset è vuoto. `.first()` ordina il queryset e recupera una riga completa, con tutte le colonne deserializzate in un'istanza del modello, soltanto perché il risultato venga poi scartato dal confronto `is None`. `.exists()` chiede al database soltanto se esista una riga. Se l'oggetto serve in seguito, mantieni `.first()` e riutilizza l'istanza; questa regola riguarda il caso in cui la riga recuperata viene scartata. La QuickFix ("Rewrite to not .exists()") può essere applicata automaticamente in sicurezza.
+
+## Non corretto
+
+```python
+if Subscription.objects.filter(user=user).first() is None:
+    prompt_upgrade()
+```
+
+## Corretto
+
+```python
+if not Subscription.objects.filter(user=user).exists():
+    prompt_upgrade()
+```
+
+## Soppressione
+
+```python
+# django-orm-lens-disable-next-line DOL003
+```
+
+In alternativa, disattiva la regola per l'area di lavoro in `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL003": "off"}}`.

--- a/docs/i18n/rules/it/DOL003.md
+++ b/docs/i18n/rules/it/DOL003.md
@@ -1,4 +1,4 @@
-# DOL003 - Preferire not .exists() a .first() is None
+# DOL003 — Preferire not .exists() a .first() is None
 
 **Gravità predefinita:** info · **Applicabilità:** safe · **Categoria:** queryset
 

--- a/docs/i18n/rules/it/DOL004.md
+++ b/docs/i18n/rules/it/DOL004.md
@@ -1,4 +1,4 @@
-# DOL004 - Preferire .exists() a .first() is not None
+# DOL004 — Preferire .exists() a .first() is not None
 
 **Gravità predefinita:** info · **Applicabilità:** safe · **Categoria:** queryset
 

--- a/docs/i18n/rules/it/DOL004.md
+++ b/docs/i18n/rules/it/DOL004.md
@@ -1,0 +1,27 @@
+# DOL004 - Preferire .exists() a .first() is not None
+
+**Gravità predefinita:** info · **Applicabilità:** safe · **Categoria:** queryset
+
+Rileva `qs.first() is not None` usato come test di esistenza. Come in DOL003, questo recupera e materializza un'intera riga soltanto per scartarla dopo un confronto con `None`; `.exists()` esegue `SELECT 1 ... LIMIT 1` e trasferisce soltanto la risposta. Mantieni `.first()` solo quando utilizzi successivamente l'istanza restituita. La QuickFix ("Rewrite to .exists()") è semanticamente identica e può essere applicata automaticamente in sicurezza.
+
+## Non corretto
+
+```python
+if Invite.objects.filter(email=email).first() is not None:
+    raise AlreadyInvited
+```
+
+## Corretto
+
+```python
+if Invite.objects.filter(email=email).exists():
+    raise AlreadyInvited
+```
+
+## Soppressione
+
+```python
+# django-orm-lens-disable-next-line DOL004
+```
+
+In alternativa, disattiva la regola per l'area di lavoro in `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL004": "off"}}`.

--- a/docs/i18n/rules/it/DOL005.md
+++ b/docs/i18n/rules/it/DOL005.md
@@ -1,0 +1,27 @@
+# DOL005 - Considerare Q(...) al posto della catena .filter().exclude()
+
+**Gravità predefinita:** hint · **Applicabilità:** suggestion · **Categoria:** queryset
+
+Rileva una catena `.filter(...).exclude(...)` su una singola riga. In genere, la coppia può essere condensata in un unico `.filter(Q(...) & ~Q(...))`: una sola espressione che descrive l'intero predicato, invece di due chiamate concatenate che chi legge deve comporre mentalmente. Entrambe le forme vengono già compilate in un'unica query, quindi la regola riguarda la leggibilità, non la velocità. È un suggerimento, non un errore: sulle relazioni multivalore, che attraversano un `ManyToManyField` o una FK inversa, `.exclude(...)` e `~Q(...)` **non** sono equivalenti. `.exclude()` rimuove gli oggetti per i quali una qualsiasi riga correlata soddisfa la condizione, mentre `~Q` applica il filtro a ciascuna riga del join. Verifica il comportamento prima di riscrivere; intenzionalmente non è disponibile alcuna QuickFix.
+
+## Non corretto
+
+```python
+posts = Post.objects.filter(published=True).exclude(author=request.user)
+```
+
+## Corretto
+
+```python
+from django.db.models import Q
+
+posts = Post.objects.filter(Q(published=True) & ~Q(author=request.user))
+```
+
+## Soppressione
+
+```python
+# django-orm-lens-disable-next-line DOL005
+```
+
+In alternativa, disattiva la regola per l'area di lavoro in `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL005": "off"}}`.

--- a/docs/i18n/rules/it/DOL005.md
+++ b/docs/i18n/rules/it/DOL005.md
@@ -1,4 +1,4 @@
-# DOL005 - Considerare Q(...) al posto della catena .filter().exclude()
+# DOL005 — Considerare Q(...) al posto della catena .filter().exclude()
 
 **Gravità predefinita:** hint · **Applicabilità:** suggestion · **Categoria:** queryset
 

--- a/docs/i18n/rules/it/DOL006.md
+++ b/docs/i18n/rules/it/DOL006.md
@@ -1,0 +1,27 @@
+# DOL006 - Eliminare list() attorno a un QuerySet in un ciclo for
+
+**Gravità predefinita:** info · **Applicabilità:** safe · **Categoria:** queryset
+
+Rileva `for x in list(qs):` quando `qs` è un'espressione che ha la forma di un queryset. Racchiudere il queryset in `list()` forza immediatamente la valutazione completa e alloca un elenco separato contenente ogni riga prima che inizi la prima iterazione del ciclo. Le istanze del modello non vengono duplicate, perché il queryset conserva nella cache gli stessi oggetti, ma il contenitore aggiuntivo è un puro sovraccarico. I QuerySet sono già iterabili, quindi rimuovere il wrapper elimina tale costo. Nota che nemmeno iterare direttamente un queryset equivale allo streaming: `_result_cache` viene comunque riempita con l'intero insieme dei risultati. Per leggere una tabella di grandi dimensioni in blocchi serve una chiamata esplicita a `.iterator()`, il cui scopo verrebbe vanificato da `list()`. La QuickFix ("Drop list() and iterate directly") rimuove soltanto il wrapper `list(...)` e può essere applicata automaticamente in sicurezza.
+
+## Non corretto
+
+```python
+for user in list(User.objects.filter(is_active=True)):
+    send_digest(user)
+```
+
+## Corretto
+
+```python
+for user in User.objects.filter(is_active=True):
+    send_digest(user)
+```
+
+## Soppressione
+
+```python
+# django-orm-lens-disable-next-line DOL006
+```
+
+Chiama `list()` intenzionalmente soltanto quando serve, per esempio per acquisire un'istantanea dei risultati prima di modificare le righe all'interno del ciclo; in quel caso, sopprimi la segnalazione. In alternativa, disattiva la regola per l'area di lavoro in `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL006": "off"}}`.

--- a/docs/i18n/rules/it/DOL006.md
+++ b/docs/i18n/rules/it/DOL006.md
@@ -1,4 +1,4 @@
-# DOL006 - Eliminare list() attorno a un QuerySet in un ciclo for
+# DOL006 — Eliminare list() attorno a un QuerySet in un ciclo for
 
 **Gravità predefinita:** info · **Applicabilità:** safe · **Categoria:** queryset
 

--- a/docs/i18n/rules/it/DOL007.md
+++ b/docs/i18n/rules/it/DOL007.md
@@ -1,4 +1,4 @@
-# DOL007 - Possibile N+1: accesso a un attributo dentro un ciclo for
+# DOL007 — Possibile N+1: accesso a un attributo dentro un ciclo for
 
 **Gravità predefinita:** warning · **Applicabilità:** unsafe · **Categoria:** queryset
 

--- a/docs/i18n/rules/it/DOL007.md
+++ b/docs/i18n/rules/it/DOL007.md
@@ -1,0 +1,51 @@
+# DOL007 - Possibile N+1: accesso a un attributo dentro un ciclo for
+
+**Gravità predefinita:** warning · **Applicabilità:** unsafe · **Categoria:** queryset
+
+Rileva `for x in <queryset>:` seguito da un accesso `x.<attr>` nel corpo del ciclo, limitandosi alle prime 15 righe. Gli attributi `id`, `pk`, `save` e quelli con prefisso di sottolineatura vengono ignorati; viene prodotta una sola segnalazione per ciclo. Se `<attr>` è un `ForeignKey` o un `OneToOneField`, ogni iterazione genera una query separata: il classico problema N+1, con una query per il ciclo più una per ogni riga. `select_related()` (join SQL) o `prefetch_related()` (seconda query eseguita in blocco) riducono il totale a un numero costante di query.
+
+La regola rimane `unsafe` e non offre alcuna QuickFix: la correzione richiede una valutazione sul modo in cui viene utilizzato il queryset, non una modifica meccanica.
+
+## Due condizioni evitano segnalazioni sul codice privo di costi aggiuntivi
+
+Fino alla versione 0.18.0 la regola considerava soltanto la forma delle righe, quindi si attivava su una normale colonna, su una proprietà Python ereditata e persino su una chiave esterna già attraversata dalla stessa istruzione: [#85](https://github.com/FROWNINGdev/django-orm-lens/issues/85). Due condizioni ora riproducono il comportamento che l'analizzatore [`nplusone`](../../../rules/nplusone.md) della CLI ha sempre adottato e sono volutamente indipendenti.
+
+**Scalare (richiede l'indice dell'area di lavoro).** Un attributo che lo schema dichiara come campo non relazionale viene ignorato. Lo stesso vale per un attributo che un modello *conosciuto* non dichiara affatto: dall'esterno, una `@property` su una classe base astratta appare in questo modo, ed è proprio considerarla una relazione che generava la maggior parte dei falsi positivi. Prima del completamento della prima scansione dell'area di lavoro, questa condizione rimane semplicemente disattivata. Un avvio a freddo si comporta quindi come in precedenza, invece di produrre segnalazioni certe sulla base di uno schema non ancora disponibile.
+
+**Già coperta (non richiede nulla).** Una relazione indicata in `.select_related(...)` o `.prefetch_related(...)` nella catena che ha prodotto il ciclo viene ignorata, incluso un `.select_related()` senza argomenti, che attraversa ogni FK. Si tratta di un semplice confronto testuale, quindi funziona anche durante un avvio a freddo ed evita che la regola contraddica codice che ha già seguito il suo stesso consiglio.
+
+La catena viene cercata sia nell'assegnazione sia nell'intestazione del ciclo, fino a 40 righe prima e attraverso le continuazioni di riga, perché `codes = list(OneTimeCode.objects.select_related("issued_by"))` seguito da `for code in codes:` è il modo abituale di scrivere questo codice. La ricerca si ferma al limite di una definizione `def`/`class` e davanti a un'assegnazione che non riconosce, invece di proseguire fino a un'assegnazione precedente con lo stesso nome.
+
+Un modello non presente nell'indice non viene considerato "scalare": in quel caso la regola ripristina il comportamento precedente alla versione 0.18, così una scansione parziale non può nascondere segnalazioni reali.
+
+## Quali cicli rientrano nell'analisi
+
+L'intestazione del ciclo viene letta come testo e la decisione dipende esclusivamente dall'iterabile.
+
+Un iterabile che non contiene `(`, cioè un nome semplice (`for user in users:`) o una catena puntata (`for entry in self.pending:`), rientra nell'analisi. Non indica alcuna chiamata, quindi una singola riga non fornisce elementi per decidere e `users = User.objects.all()` è una forma comune. Per lo stesso motivo, anche un nome associato a un elenco rientra nell'analisi: `k_entries = ["a", "b"]` seguito da `for e in k_entries: print(e.upper)` viene segnalato.
+
+Un iterabile che contiene `(` rientra nell'analisi soltanto quando il testo precedente alla prima `(` è formato esattamente da tre segmenti separati da punti, con `objects` al centro (`<Model>.objects.<method>`), oppure è una catena puntata il cui segmento finale è un metodo che produce un queryset (`all`, `filter`, `exclude`, `annotate`, `distinct`, `order_by`, `values`, `values_list`, `reverse`, `none`, `iterator`, `only`, `defer`, `using`, `alias`, `dates`, `datetimes`, `union`, `intersection`, `difference`, `select_related`, `prefetch_related`, `extra`, `select_for_update`, `raw`).
+
+Ogni altra sorgente che contiene una chiamata viene ignorata: `range(10)`, `os.listdir(path)`, `apps.get_models()` e una funzione di supporto come `auditory_models()` o `self.get_queryset()`. Il solo nome della chiamata non dice nulla sul valore restituito e scoprirlo richiederebbe di seguire il risultato della funzione, operazione che necessita dell'AST non disponibile a questa regola orientata alle singole righe. Il prezzo è un falso negativo: anche una funzione di supporto che restituisce effettivamente un queryset viene ignorata.
+
+## Non corretto
+
+```python
+for post in Post.objects.all():
+    print(post.author.name)   # one extra query per post
+```
+
+## Corretto
+
+```python
+for post in Post.objects.select_related("author"):
+    print(post.author.name)   # single joined query
+```
+
+## Soppressione
+
+```python
+# django-orm-lens-disable-next-line DOL007
+```
+
+In alternativa, disattiva la regola per l'area di lavoro in `.vscode/settings.json`: `{"djangoOrmLens.rules": {"DOL007": "off"}}`.

--- a/docs/i18n/rules/it/DOL008.md
+++ b/docs/i18n/rules/it/DOL008.md
@@ -1,4 +1,4 @@
-# DOL008 - Il nome del campo in un lookup sembra contenere un refuso
+# DOL008 — Il nome del campo in un lookup sembra contenere un refuso
 
 **Gravità predefinita:** warning · **Applicabilità:** suggestion · **Categoria:** correctness
 

--- a/docs/i18n/rules/it/DOL008.md
+++ b/docs/i18n/rules/it/DOL008.md
@@ -1,0 +1,58 @@
+# DOL008 - Il nome del campo in un lookup sembra contenere un refuso
+
+**Gravità predefinita:** warning · **Applicabilità:** suggestion · **Categoria:** correctness
+
+Segnala un segmento di un percorso di lookup all'interno di `filter()`, `exclude()`, `get()` e metodi analoghi quando è **sia** sconosciuto **sia** ortograficamente simile a un nome riconosciuto. `Post.objects.filter(titel="x")` viene segnalato suggerendo `title`; una QuickFix sostituisce soltanto quel segmento, lasciando invariati il resto del percorso e il valore.
+
+Django genera un `FieldError` per un nome di lookup errato, ma soltanto quando il queryset viene valutato. Se il filtro è annidato in una diramazione del codice, ciò potrebbe avvenire in produzione anziché durante un test.
+
+## Perché si attiva soltanto in presenza di un nome simile
+
+"Non riconosco questo nome" è un'affermazione poco precisa. Annotazioni, lookup personalizzati registrati con `register_lookup`, campi provenienti da un mixin che il parser non è riuscito a leggere e `GenericForeignKey` sono tutti elementi validi, ma assenti dallo schema analizzato. Una regola basata su quell'affermazione sottolinea codice corretto e un avviso che talvolta è sbagliato insegna a disattivare l'estensione.
+
+"Questo sembra un refuso di *quello*" è un'affermazione molto precisa e offre anche un intervento concreto. Per questo motivo, un nome che non somiglia ad alcun elemento, come `zzzqqq` o l'alias di un'annotazione, viene ignorato e viene segnalato soltanto un nome quasi corrispondente.
+
+La distanza consentita varia in base alla lunghezza: una modifica per i nomi di quattro caratteri o meno, due per quelli più lunghi. Il primo carattere deve coincidere, perché in genere è la lettera che viene digitata correttamente anche quando si sbaglia il resto; senza questo vincolo, i nomi brevi verrebbero associati tra loro in tutto il modello.
+
+## Perché non può attivarsi su un elemento offerto dal completamento
+
+Il controllo chiede al risolutore del completamento quali nomi siano validi in quella posizione e segnala soltanto quelli assenti dall'elenco. Non è una seconda copia più debole della logica di risoluzione, ma la stessa logica. La regola ignora quindi automaticamente tutto ciò che il completamento comprende:
+
+- campi ereditati da classi base astratte, incluse quelle dichiarate in un altro file
+- accessor inversi, definiti da `related_name` o dal nome del modello in minuscolo
+- `pk`
+- lookup tipizzati per campo (`icontains` su un `CharField`, `year` su un `DateTimeField`)
+
+Questa proprietà spiega perché la regola sia stata introdotta in seguito. Gli accessor inversi sono arrivati nella versione 0.15.0, i campi ereditati nella 0.16.0 e le classi base definite in altri file nella 0.17.0. Se fosse stata pubblicata prima, avrebbe sottolineato `Author.objects.filter(posts__title=...)`, che è normale codice Django.
+
+## Quando rimane completamente silenziosa
+
+- Il modello non viene risolto, per esempio in un file non analizzato o quando il queryset viene costruito in un modo non seguito dal risolutore. Senza schema, la regola non esprime alcun giudizio.
+- La riga contiene `.annotate()`, `.alias()` o `.extra()`. Questi metodi introducono nomi validi nelle operazioni successive che non esistono in alcun modello.
+- Gli argomenti contengono una chiamata annidata, come `Q(...)`, `F(...)` o una sottoquery, nella quale un nome semplice non deve necessariamente essere un campo.
+- Il segmento sconosciuto non somiglia ad alcun elemento.
+- Dopo il primo segmento sconosciuto di un percorso: ogni elemento successivo dipende da qualcosa che non è stato risolto e quindi non può essere valutato ulteriormente.
+
+## Non corretto
+
+```python
+Post.objects.filter(titel="django")          # DOL008: did you mean title?
+Post.objects.filter(author__emial="a@b.c")   # DOL008: did you mean email?
+Post.objects.filter(title__icontans="x")     # DOL008: did you mean icontains?
+```
+
+## Corretto
+
+```python
+Post.objects.filter(title="django")
+Post.objects.filter(author__email="a@b.c")
+Post.objects.filter(title__icontains="x")
+```
+
+## Soppressione
+
+```python
+Post.objects.filter(titel="x")  # noqa: DOL008
+```
+
+Imposta `djangoOrmLens.rules.DOL008` su `"off"` per disattivare la regola oppure `djangoOrmLens.codeFixes.enabled` su `false` per disattivare l'intero insieme di regole.

--- a/docs/i18n/rules/it/README.md
+++ b/docs/i18n/rules/it/README.md
@@ -1,8 +1,21 @@
 # Riferimento delle regole
 
-Questa sezione contiene la traduzione italiana delle regole di Django ORM Lens relative alla definizione dei modelli. Ogni codice `DOL` identifica un controllo statico eseguito dall'estensione VS Code durante la scrittura del codice.
+Questa sezione contiene la traduzione italiana delle regole di Django ORM Lens relative ai queryset e alla definizione dei modelli. Ogni codice `DOL` identifica un controllo statico eseguito dall'estensione VS Code durante la scrittura del codice.
 
 Per le regole non ancora tradotte, consulta il [riferimento completo in inglese](../../../rules/README.md).
+
+## Regole sui queryset
+
+| Codice | Regola | Categoria | Gravità predefinita | Applicabilità |
+|---|---|---|---|---|
+| [DOL001](DOL001.md) | Preferire `.exists()` a `.count() > 0` | queryset | info | safe |
+| [DOL002](DOL002.md) | Preferire `not .exists()` a `.count() == 0` | queryset | info | safe |
+| [DOL003](DOL003.md) | Preferire `not .exists()` a `.first() is None` | queryset | info | safe |
+| [DOL004](DOL004.md) | Preferire `.exists()` a `.first() is not None` | queryset | info | safe |
+| [DOL005](DOL005.md) | Considerare `Q(...)` al posto della catena `.filter().exclude()` | queryset | hint | suggestion |
+| [DOL006](DOL006.md) | Eliminare `list()` attorno a un QuerySet in un ciclo `for` | queryset | info | safe |
+| [DOL007](DOL007.md) | Possibile N+1: accesso a un attributo dentro un ciclo `for` | queryset | warning | unsafe |
+| [DOL008](DOL008.md) | Il nome del campo in un lookup sembra contenere un refuso | correctness | warning | suggestion |
 
 ## Regole di definizione dei modelli
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,6 +1,6 @@
 # Rule reference
 
-🌐 [Italiano](../i18n/rules/it/README.md) - queryset and model rules (`DOL001`-`DOL008`, `DOL011`-`DOL015`)
+🌐 [Italiano](../i18n/rules/it/README.md) — queryset and model rules (`DOL001`–`DOL008`, `DOL011`–`DOL015`)
 🌐 [Tiếng Việt](../i18n/rules/vi/README.md) — queryset rules (`DOL001`–`DOL007`)
 
 Django ORM Lens ships two rule surfaces:

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,6 +1,6 @@
 # Rule reference
 
-🌐 [Italiano](../i18n/rules/it/README.md) — model rules (`DOL011`–`DOL015`)
+🌐 [Italiano](../i18n/rules/it/README.md) - queryset and model rules (`DOL001`-`DOL008`, `DOL011`-`DOL015`)
 🌐 [Tiếng Việt](../i18n/rules/vi/README.md) — queryset rules (`DOL001`–`DOL007`)
 
 Django ORM Lens ships two rule surfaces:


### PR DESCRIPTION
## Summary

Added Italian translations for the queryset rule family (`DOL001` through `DOL008`). I read and write Italian and reviewed the wording for technical accuracy while keeping code blocks, rule identifiers, settings, QuickFix labels, and suppression syntax unchanged.

Updated the Italian locale index with the new family, expanded the coverage label in the complete rule reference, and recorded the addition in the changelog.

## Type of change

- [ ] Bug fix (non-breaking, restores expected behaviour)
- [ ] Feature (non-breaking, adds a capability)
- [ ] Breaking change (existing users have to update config or code)
- [x] Docs / README / comments only (no runtime effect)
- [ ] Internal refactor (no behaviour change, no public API change)
- [ ] Dependency bump
- [ ] CI / build / tooling

## Test plan

- Compared all 24 fenced Python code blocks with the English source after repository line-ending normalization; their contents are identical.
- Verified identical line counts and heading structure for every translated page.
- Verified that inline technical tokens match the English source exactly.
- Verified that category, default severity, and applicability match the canonical index for all eight rules.
- Verified that every relative Markdown link in the Italian locale resolves.
- Ran `npm test`: 242 tests passed.
- Ran `cd cli && python -m pytest -q`: 475 tests and 41 subtests passed, with 2 tests skipped.
- Ran `cd cli && python -m ruff check django_orm_lens tests`: passed.
- Ran `cd cli && python -m mypy django_orm_lens`: passed.
- Ran `git diff --check`: passed.

## Checklist

- [x] I ran the full test suite locally (`cd cli && pytest -q` for Python, `npm test` for TypeScript) and it is green
- [ ] I added or updated tests that cover the change (bugfixes should get a regression test)
- [x] If the change is user-facing I updated the CHANGELOG under `## [Unreleased]`
- [ ] If the change touches the MCP tool contract (new tool, new arg, new error code) I updated the tool description in `mcp_server.py` and the relevant tests in `test_mcp_server.py`
- [ ] If this is a breaking change I called it out under `## Summary` above and suggested a migration path

The unchecked items do not apply because this PR changes Markdown documentation only and does not change runtime behavior or the MCP contract.

## Related issues / discussions

Closes #98

Refs #52


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Italian documentation for queryset rules DOL001–DOL008, including examples, guidance, severities, and configuration options.
  * Updated the Italian rules index with links and details for DOL001–DOL008.
  * Updated the main rules reference to include Italian queryset and model rule documentation.
  * Added an Unreleased changelog entry for the Italian translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->